### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,7 +30,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 


### PR DESCRIPTION
Bumps `actions/checkout@v4` → `@v5` in the R-CMD-check workflow.

Resolves the GitHub Actions deprecation warning seen on the previous run: `actions/checkout@v4` runs on Node.js 20, which will be forced to Node 24 starting 2026-06-16. v5 runs on Node 24 natively.

No other changes; the r-lib/actions steps already support Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)