### PR TITLE
Release 0.1.2

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,7 +11,6 @@
 ^revdep$
 ^vignettes/.*_cache$
 ^vignettes/.*\.html$
-^NEWS\.md$
 ^.DS_Store$
 ^cran-comments\.md$
 ^CRAN-SUBMISSION$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: DT2
 Type: Package
 Title: 'DataTables' 2.x for R
-Version: 0.1.1
-Date: 2026-04-29
+Version: 0.1.2
+Date: 2026-06-13
 Authors@R: c(
     person("Andre", "Leite", email = "leite@castlab.org", role = c("aut", "cre")),
     person("Marcos", "Wasilew", email = "marcos.wasilew@gmail.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,48 @@
+# DT2 0.1.2
+
+## Bug fixes
+
+* `dt2_cols_escape()` now actually escapes HTML when `escape = TRUE` (the
+  default). Previously both `escape = TRUE` and `escape = FALSE` produced the
+  same identity renderer, so cell content was always inserted as raw HTML.
+
+* Server-side processing: the default request parser used by
+  `dt2_ssp_handler()` / `dt2_bind_server()` now URL-decodes query-string
+  *keys*, so global search and column ordering are applied. Previously only
+  pagination worked, because encoded keys such as `search%5Bvalue%5D` and
+  `order%5B0%5D%5Bcolumn%5D` were never matched.
+
+## Improvements
+
+* `dt2()` now fills `options$columns` from the data when it is not supplied,
+  matching the column list the JavaScript side derives.
+
+* Name-based column helpers (`dt2_cols_*()`, `dt2_format_*()`, `dt2_order()`,
+  ...) now emit an informative warning when a column name cannot be resolved
+  (for example when `options$columns` was not set), instead of silently
+  producing an invalid target.
+
+* The number and date/time format helpers build their JavaScript using
+  properly quoted and escaped string literals, fixing broken output when a
+  prefix, suffix, locale or format string contained a quote.
+
+* `print()` for `dt2_theme` objects now also shows the `class` field.
+
+## Documentation and infrastructure
+
+* Added a test suite (testthat) covering the fixes above.
+* Added a GitHub Actions R-CMD-check workflow.
+* Reorganised the pkgdown reference index into thematic sections, added
+  runnable examples to `dt2_order()`, `dt2_search_global()`,
+  `dt2_use_buttons()` and `dt2_language()`, cross-linked
+  `dt2_buttons()`/`dt2_use_buttons()`, and documented the `options$columns`
+  pattern in the vignettes.
+* New package logo.
+
+# DT2 0.1.1
+
+* First CRAN release.
+
+# DT2 0.1.0
+
+* Initial development version.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,34 +1,26 @@
-## Resubmission
+## Update
 
-This is a resubmission addressing the comments from Benjamin Altmann
-(2026-04-08):
+This is a minor update (0.1.2) of a package already on CRAN. It fixes two
+bugs and improves robustness; see NEWS.md for the full list. The most
+user-visible changes are:
 
-* Title and Description now use single quotes only around package /
-  software / API names ('DataTables', 'Bootstrap 5', 'Shiny',
-  'JavaScript'). The reference to R itself is no longer quoted.
+* `dt2_cols_escape()` now escapes HTML when `escape = TRUE` (previously the
+  argument had no effect).
+* The default server-side processing handler now applies global search and
+  column ordering (query-string keys were not being URL-decoded).
 
-* Added \value tags to all exported functions that were missing them:
-  dt2_bind_server, dt2_draw, dt2_format_time_relative, dt2_output,
-  dt2_proxy_order, dt2_replace_data, dt2_select_rows,
-  observe_dt2_events, render_dt2.
+There are no reverse dependencies on CRAN.
 
-* Replaced \dontrun{} examples:
-  - dt2_format_number, dt2_format_datetime, dt2_cols_render_orthogonal:
-    examples unwrapped (they only build option lists and run in < 1s).
-  - dt2_check_updates: changed to \donttest{}, since it reaches the
-    npm registry over the network.
-  - dt2_update_libs: kept as \dontrun{} (with an explanatory comment),
-    because this is a developer-only tool that requires the DT2 package
-    source tree (DESCRIPTION, tools/get-dt2-libs.sh, R/dt2_extensions.R)
-    and therefore truly cannot be executed by the user from an installed
-    package or from a CRAN check environment.
+## Test environments
+
+* local macOS, R 4.6.0
+* GitHub Actions: ubuntu-latest (r-devel, r-release, r-oldrel-1),
+  macOS-latest (r-release), windows-latest (r-release)
 
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
+0 errors | 0 warnings | 0 notes
 
-* checking CRAN incoming feasibility ... NOTE
-  Maintainer: 'Andre Leite <leite@castlab.org>'
-  New submission
-
-  This NOTE is expected for a first-time submission.
+The package bundles the 'DataTables' JavaScript library and its extensions,
+so the installed size may be reported as a NOTE on some CRAN check machines
+(unchanged from 0.1.1).


### PR DESCRIPTION
Prepares the **0.1.2** patch release (DT2 0.1.1 is already on CRAN).

## Changes
- Bump version `0.1.1` → `0.1.2` (`Date: 2026-06-13`).
- Add **`NEWS.md`** with the changelog since 0.1.1 (the escape/SSP bug fixes, the `options$columns` improvements, JS-string safety, tests, CI, docs).
- Remove `^NEWS\.md$` from `.Rbuildignore` so the changelog ships in the tarball (and pkgdown can build a Changelog page).
- Update `cran-comments.md` for an **update** submission (no longer a new submission).

## CRAN readiness — local results
- `R CMD check --as-cran`: **0 errors · 0 warnings · 0 notes** ✔
- `urlchecker::url_check()`: **all URLs correct** ✔
- `devtools::spell_check()`: only domain terms / proper nouns (no real typos)
- GitHub Actions R-CMD-check: green on ubuntu (devel/release/oldrel-1), macOS, windows

## Before submitting (maintainer action)
CRAN expects a win-builder pass that can't be produced locally:
- `devtools::check_win_devel()` (and optionally `check_win_release()`)
- then `devtools::submit_cran()` or the CRAN web form

🤖 Generated with [Claude Code](https://claude.com/claude-code)