### PR TITLE
fix: clear CRAN example-timing NOTE for 0.1.2 resubmission

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: DT2
 Type: Package
 Title: 'DataTables' 2.x for R
 Version: 0.1.2
-Date: 2026-06-13
+Date: 2026-06-14
 Authors@R: c(
     person("Andre", "Leite", email = "leite@castlab.org", role = c("aut", "cre")),
     person("Marcos", "Wasilew", email = "marcos.wasilew@gmail.com", role = "aut"),

--- a/R/dt2.R
+++ b/R/dt2.R
@@ -56,8 +56,10 @@
 #' @examples
 #' # Create and reuse
 #' my_theme <- dt2_theme("clean", compact = TRUE)
+#' \donttest{
 #' dt2(iris, theme = my_theme)
 #' dt2(mtcars, theme = my_theme)
+#' }
 #'
 #' # Custom button style
 #' dt2_theme("default", button_class = "btn btn-sm btn-primary")
@@ -161,6 +163,7 @@ print.dt2_theme <- function(x, ...) {
 #' # Just works — beautiful defaults
 #' dt2(iris)
 #'
+#' \donttest{
 #' # Override style inline
 #' dt2(iris, striped = FALSE)
 #' dt2(iris, font_scale = 0.85, compact = FALSE)
@@ -204,6 +207,7 @@ print.dt2_theme <- function(x, ...) {
 #'       buttons = list("copy", "csv", "excel"),
 #'       layout = list(topEnd = "buttons")
 #'     ))
+#' }
 dt2 <- function(data,
                 # ---- styling ----
                 theme        = "default",

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,11 @@
+## Resubmission
+
+This is a resubmission of 0.1.2. The previous submission was flagged by the
+incoming pre-test with one NOTE on r-devel-windows: the `dt2()` examples ran
+in > 10s elapsed. I have wrapped all but one minimal `dt2()` example in
+`\donttest{}` (in `dt2()` and `dt2_theme()`), so the timed example run is now
+well under the threshold. No code was changed.
+
 ## Update
 
 This is a minor update (0.1.2) of a package already on CRAN. It fixes two

--- a/man/dt2.Rd
+++ b/man/dt2.Rd
@@ -75,6 +75,7 @@ JavaScript API). The two concerns are cleanly separated.
 # Just works — beautiful defaults
 dt2(iris)
 
+\donttest{
 # Override style inline
 dt2(iris, striped = FALSE)
 dt2(iris, font_scale = 0.85, compact = FALSE)
@@ -118,4 +119,5 @@ dt2(mtcars,
       buttons = list("copy", "csv", "excel"),
       layout = list(topEnd = "buttons")
     ))
+}
 }

--- a/man/dt2_theme.Rd
+++ b/man/dt2_theme.Rd
@@ -46,8 +46,10 @@ For quick one-off styling, you can also pass arguments directly to
 \examples{
 # Create and reuse
 my_theme <- dt2_theme("clean", compact = TRUE)
+\donttest{
 dt2(iris, theme = my_theme)
 dt2(mtcars, theme = my_theme)
+}
 
 # Custom button style
 dt2_theme("default", button_class = "btn btn-sm btn-primary")


### PR DESCRIPTION
## Why

CRAN's incoming pre-test rejected the 0.1.2 submission with one NOTE on r-devel-windows:

```
Examples with CPU (user + system) or elapsed time > 10s
        user system elapsed
  dt2   0.88   1.48   19.01
```

## What

- Wrap all but one minimal `dt2(iris)` example in `\donttest{}` (in both `dt2()` and `dt2_theme()`). The timed example run drops from ~19s elapsed to **~0.5s**.
- No package code changed — only roxygen example blocks (and regenerated Rd).
- Bump `Date` to 2026-06-14; add a "Resubmission" note to `cran-comments.md`.

## Verification

`R CMD check` with `_R_CHECK_TIMINGS_=10` → **Status: OK**, no example NOTE. Total example time now 0.477s elapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)