### PR TITLE
ci: bump checkout to v5 in pkgdown workflow (Node 24)

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 


### PR DESCRIPTION
One-line follow-up to #14: bumps `actions/checkout@v4` → `@v5` in `pkgdown.yaml` to clear the "Node.js 20 is deprecated" Actions warning. Matches the version already used in `R-CMD-check.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)