### PR TITLE
docs: add Python port (dt2) cross-reference badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 ![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/DT2) 
 ![CRAN Downloads](https://cranlogs.r-pkg.org/badges/grand-total/DT2) 
 ![License](https://img.shields.io/badge/license-MIT-darkviolet.svg) 
-![Devel Badge](https://img.shields.io/badge/devel%20version-0.1.1-blue.svg)
+![Devel Badge](https://img.shields.io/badge/devel%20version-0.1.1-blue.svg) 
+[![Python port: dt2](https://img.shields.io/pypi/v/dt2?label=Python%3A%20dt2&logo=python&logoColor=white)](https://github.com/StrategicProjects/dt2py)
 <!-- badges: end -->
 
 > **DataTables v2 for R** — modular, lightweight, works with or without Shiny.


### PR DESCRIPTION
Adds a badge to the README badge block linking to the Python port [dt2](https://github.com/StrategicProjects/dt2py) (shows its current PyPI version). Symmetric with the `R package: DT2` badge added to the dt2py README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)