### PR TITLE
docs: bump devel version badge to 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/DT2) 
 ![CRAN Downloads](https://cranlogs.r-pkg.org/badges/grand-total/DT2) 
 ![License](https://img.shields.io/badge/license-MIT-darkviolet.svg) 
-![Devel Badge](https://img.shields.io/badge/devel%20version-0.1.1-blue.svg) 
+![Devel Badge](https://img.shields.io/badge/devel%20version-0.1.2-blue.svg) 
 [![Python port: dt2](https://img.shields.io/pypi/v/dt2?label=Python%3A%20dt2&logo=python&logoColor=white)](https://github.com/StrategicProjects/dt2py)
 <!-- badges: end -->
 


### PR DESCRIPTION
The README devel-version badge still read `0.1.1`; DESCRIPTION is at `0.1.2`. Sync the badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)