### PR TITLE
chore: gitignore .claude/ (local agent config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,6 @@ po/*~
 rsconnect/
 .positai
 
-# Local agent instructions (not versioned)
+# Local agent instructions / config (not versioned)
 CLAUDE.md
+.claude/


### PR DESCRIPTION
Adds `.claude/` to `.gitignore` so the local Claude Code config (e.g. `settings.local.json`) is protected portably by the repo itself, not only by a machine-specific global gitignore. Mirrors the same change in dt2py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)